### PR TITLE
build: add publish access for scoped package publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "url": "https://github.com/edx/reactifex/issues"
   },
   "homepage": "https://github.com/edx/reactifex#readme",
+  "publishConfig": {
+    "access": "public"
+  },
   "devDependencies": {
     "eslint": "^7.32.0",
     "eslint-config-airbnb": "^18.2.1",


### PR DESCRIPTION
### [PROD-2524](https://openedx.atlassian.net/browse/PROD-2524)

### Description
Add public publish config to allow the publish of scoped(`@edx`) package as a public package.

- https://stackoverflow.com/questions/45820881/npm-publish-failed-put-402
- https://docs.npmjs.com/about-scopes