### PR TITLE
Revert "build: add publish access for scoped package publish"

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,6 @@
     "url": "https://github.com/edx/reactifex/issues"
   },
   "homepage": "https://github.com/edx/reactifex#readme",
-  "publishConfig": {
-    "access": "public"
-  },
   "devDependencies": {
     "eslint": "^7.32.0",
     "eslint-config-airbnb": "^18.2.1",


### PR DESCRIPTION
Reverts edx/reactifex#5

Temporary revert to change the commit message in a follow-up PR to trigger the publish to npm.