### PR TITLE
fix: fix npm publish by making scoped package access public

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
   "bugs": {
     "url": "https://github.com/edx/reactifex/issues"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "homepage": "https://github.com/edx/reactifex#readme",
   "devDependencies": {
     "eslint": "^7.32.0",


### PR DESCRIPTION
includes the reverted changes from https://github.com/edx/reactifex/pull/6 but with an updated commit message to trigger npm publish