### PR TITLE
fix: add src directory in installed package files

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "files": [
     "main.js",
-    "bash_scripts/"
+    "bash_scripts/",
+    "src/"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
### [PROD-2548](https://openedx.atlassian.net/browse/PROD-2548)

### Description
Add **src** directory in package.json [files](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#files) field so that the directory and its contents become available when the package is installed in other packages. 