### PR TITLE
feat: update main.js to be equal to transifex utils

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Install dependencies
         run: npm install
       # The owning team will fix the issues and uncomment the steps after necessary linting and configuring changes
-      #- name: Lint
-      #  run: npm run lint
+      - name: Lint
+       run: npm run lint
 
      # - name: Test
      #   run: |

--- a/main.js
+++ b/main.js
@@ -1,38 +1,76 @@
 #!/usr/bin/env node
-const path = require("path");
-const fs = require("fs");
 
-var combineInputs = (dir) => {
-  // expected input: a directory containing subdirs, each of which contains displayMessages.json
-  var ret = [];
-  var subDirs = fs.readdirSync(dir);
-  subDirs.forEach((subdir) => {
-    var messageFile = path.join(dir, subdir, "displayMessages.json");
-    var messages = JSON.parse(fs.readFileSync(messageFile));
-    messages.forEach((message) => {ret.push(message);});
+const fs = require("fs");
+// eslint-disable-next-line import/no-extraneous-dependencies
+const glob = require("glob");
+const path = require("path");
+
+/*
+ * See the Makefile for how the required hash file is downloaded from Transifex.
+ */
+
+/*
+ * Expected input: a directory, possibly containing subdirectories, with .json files.  Each .json
+ * file is an array of translation triplets (id, description, defaultMessage).
+ *
+ *
+ */
+function gatherJson(dir) {
+  const ret = [];
+  const files = glob.sync(`${dir}/**/*.json`);
+
+  files.forEach((filename) => {
+    const messages = JSON.parse(fs.readFileSync(filename));
+    ret.push(...messages);
   });
   return ret;
-};
-var inData = combineInputs(process.argv[2]);
+}
 
-var outData = {};
-inData.forEach((message) => {
-  outData[message["id"]] = message["defaultMessage"];
-});
+// the hash file returns ids whose periods are "escaped" (sort of), like this:
+// "key": "profile\\.sociallinks\\.social\\.links"
+// so our regular messageIds won't match them out of the box
+function escapeDots(messageId) {
+  return messageId.replace(/\./g, "\\.");
+}
 
-if (process.argv[3] === "--comments") {
-  process.stdout.write("generating bash scripts...\n");
-  var messageInfo = JSON.parse(fs.readFileSync(__dirname + "/bash_scripts/hashmap.json"));
-  var dataPath = __dirname + "/bash_scripts/hashed_data.txt";
-  fs.writeFileSync(dataPath, "");
-  inData.forEach((message) => {
-    var info = messageInfo.find(mi => mi.key == message.id);
+const jsonDir = process.argv[2];
+const messageObjects = gatherJson(jsonDir);
+
+if (messageObjects.length === 0) {
+  process.exitCode = 1;
+  throw new Error("Found no messages");
+}
+
+if (process.argv[3] === "--comments") { // prepare to handle the translator notes
+  const loggingPrefix = path.basename(`${__filename}`); // the name of this JS file
+  const bashScriptsPath = (
+    process.argv[4] && process.argv[4] === "--v3-scripts-path"
+      ? "./node_modules/@edx/reactifex/bash_scripts"
+      : "./node_modules/reactifex/bash_scripts");
+
+  const hashFile = `${bashScriptsPath}/hashmap.json`;
+  process.stdout.write(`${loggingPrefix}: reading hash file ${hashFile}\n`);
+  const messageInfo = JSON.parse(fs.readFileSync(hashFile));
+
+  const outputFile = `${bashScriptsPath}/hashed_data.txt`;
+  process.stdout.write(`${loggingPrefix}: writing to output file ${outputFile}\n`);
+  fs.writeFileSync(outputFile, "");
+
+  messageObjects.forEach((message) => {
+    const transifexFormatId = escapeDots(message.id);
+
+    const info = messageInfo.find((mi) => mi.key === transifexFormatId);
     if (info) {
-      fs.appendFileSync(dataPath, info.string_hash + "|" + message.description + "\n");
+      fs.appendFileSync(outputFile, `${info.string_hash}|${message.description}\n`);
     } else {
-      process.stdout.write("string " + message.id + " does not yet exist on transifex!\n");
+      process.stdout.write(`${loggingPrefix}: string ${message.id} does not yet exist on transifex!\n`);
     }
   });
 } else {
-  fs.writeFileSync(process.argv[3], JSON.stringify(outData, null, 2));
+  const output = {};
+
+  messageObjects.forEach((message) => {
+    output[message.id] = message.defaultMessage;
+  });
+  fs.writeFileSync(process.argv[3], JSON.stringify(output, null, 2));
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "@edx/reactifex",
   "version": "1.0.0-semantically-released",
   "description": "A helper for moving react-intl messages to transifex and back",
-  "bin": "./main.js",
+  "bin": {
+    "edx_reactifex": "./main.js"
+  },
   "scripts": {
     "lint": "eslint .",
     "test_compile": "node main.js test_data/input/ test_data/test_output.json && diff test_data/test_output.json test_data/expected_output/messages.json",


### PR DESCRIPTION
### Description

- Update main.js to be equal to [frontend-platform's transifex-utils.js](https://github.com/openedx/frontend-platform/blob/master/src/i18n/scripts/transifex-utils.js) file. This is needed to fix studio-frontend [push translation](https://github.com/openedx/studio-frontend/blob/master/Makefile#L78) job that uses reactifex's main.js to compile comments instead of frontend-platform(not installed in it)
- Enable quality test on CI
- Update package.json bin to rename main.js usage in edx/reactifex via `$(npm bin)/edx_reactifex`